### PR TITLE
Fix for issue 46

### DIFF
--- a/plugins/module_utils/hmc_rest_client.py
+++ b/plugins/module_utils/hmc_rest_client.py
@@ -187,7 +187,7 @@ def lookup_physical_io(rest_conn, server_dom, drcname):
 
     for each in physical_io_list:
         each_eletree = etree.ElementTree(each)
-        if drcname in each_eletree.xpath("//RelatedIOAdapter/IOAdapter/DynamicReconfigurationConnectorName")[0].text:
+        if drcname == each_eletree.xpath("//RelatedIOAdapter/IOAdapter/DynamicReconfigurationConnectorName")[0].text:
             return each_eletree
 
     return None


### PR DESCRIPTION
- power_hmc.powervm_lpar_instance may assign a physical_io
  location that is a superstring of the requested one