### PR TITLE
Add sample execution environment config for AAP 2

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -3,4 +3,3 @@ version: 1
 
 dependencies:
   galaxy: collections/requirements.yml
-

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -1,0 +1,6 @@
+---
+version: 1
+
+dependencies:
+  galaxy: collections/requirements.yml
+


### PR DESCRIPTION
User can use this config file and create ee image using the command '#ansible-builder build -t hmc-demo-ee'
While executing the playbook using this ee image, make sure the python interpreter set as '3.8'