### PR TITLE
Adding role for Supporting Linux OS installation

### DIFF
--- a/playbooks/redhat_linux_install.yaml
+++ b/playbooks/redhat_linux_install.yaml
@@ -1,0 +1,22 @@
+---
+- name: Install linux
+  hosts: localhost
+  collections:
+    - ibm.power_hmc
+  gather_facts: false
+  roles:
+    - role: redhat_linux_install
+      vars:
+        distro: redhat9.1
+        repo_dir: /crtl/
+        host_ip: 1.2.3.4
+        host_gw: 1.2.3.1
+        host_subnet: 1.2.3.0
+        host_netmask: 255.255.255.0
+        dns_ip: 1.6.6.6
+        hostname: zip1.pus.sub.com
+        lpar_name: vm-zip1
+        hardware_ethernet: 11:11:11:11:11:11
+        managed_system: zip1
+        host_password: "{{ hostvars[groups['vm'][0]].ansible_password }}" 
+

--- a/plugins/module_utils/hmc_resource.py
+++ b/plugins/module_utils/hmc_resource.py
@@ -549,17 +549,19 @@ class Hmc():
         self.hmcconn.execute(installiosCmd)
 
     def getconsolelog(self, module, lpar_hmc, userid, hmc_password, systemName, lparName):
-        conn = HmcCliConnection(module, lpar_hmc, userid, hmc_password)
-        cmd = 'rmvterm -m ' + systemName + ' -p ' + lparName
-        conn.execute(cmd)
-        cmd = 'mkvterm -m ' + systemName + ' -p ' + lparName
-        stdout = conn.execute(cmd)
-        try:
-            for line in stdout:
-                logger.debug(line.strip())
-                logger.debug("\n")
-        except UnicodeDecodeError:
-            pass
+        count = 0
+        while(count < 25):
+            conn = HmcCliConnection(module, lpar_hmc, userid, hmc_password)
+            cmd = 'rmvterm -m ' + systemName + ' -p ' + lparName
+            conn.execute(cmd)
+            cmd = 'mkvterm -m ' + systemName + ' -p ' + lparName
+            stdout = conn.execute(cmd)
+            try:
+                logger.debug(stdout.strip("\n"))
+            except UnicodeDecodeError:
+                pass
+            count+=1
+
 
     def checkconsolelog(self, module, lpar_ip, lpar_hmc, userid, hmc_password, systemName, lparName):
         logger.info("Installation will take approximatly 10-12 mins to complete.")

--- a/roles/redhat_linux_install/README.md
+++ b/roles/redhat_linux_install/README.md
@@ -1,0 +1,141 @@
+Role Name
+=========
+
+This Ansible role "Red Hat Linux Installation for IBM PowerVM" automates the process of installing Red Hat Enterprise Linux (RHEL) on IBM PowerVM logical partitions (LPARs) using a **network-based installation via TFTP boot**.
+
+## Overview
+
+There are multiple ways to install RHEL on IBM Power servers. This role focuses on automating the **TFTP-based network installation** method using Ansible. It sets up the necessary infrastructure and orchestrates the installation process end-to-end.
+
+## Required Infrastructure
+
+To perform the installation, the following components must be configured:
+
+1. **HTTP (Repo) Server**  
+   Hosts the RHEL distribution files and serves them via HTTP. This can be a dedicated server with multiple distro builds or a simple HTTP server with the required build.
+
+2. **PXE Server**  
+   Runs both `tftpd` and `dhcpd` services. This role will configure these services if they are not already running.
+
+3. **LPAR (Logical Partition)**  
+   The target system where RHEL will be installed.
+
+## Role Workflow
+
+1. **PXE Server Setup**  
+   - Checks for running DHCP and TFTP services.
+   - If not found, configures and enables them.
+   - DHCP configuration is dynamically generated based on the subnet of the target LPAR using the `dhcp_server_conf.j2` template.
+   - TFTP is configured to serve files from `/var/lib/tftpboot`.
+
+2. **Kickstart File Generation**  
+   - A kickstart file is created on the HTTP server containing the installation configuration.
+
+3. **Boot File Preparation**  
+   - Required boot files are downloaded to the PXE server.
+   - A GRUB configuration file is generated using the kickstart file.
+
+4. **Network Boot Trigger**  
+   - The `lpar_netboot` command is executed from the HMC to initiate a network boot on the LPAR.
+   - The LPAR sends a BOOTP request to the PXE server and begins the OS installation.
+
+5. **Post-Installation Validation**
+   - After installation, the role prints the OS distribution name and version installed on the LPAR to verify success.
+
+
+Role Variables
+--------------
+
+1. distro:  
+   * type: str
+   * required: true
+   * description: Redhat distribution version in format Redhat9.3
+
+2. repo_port:
+   * type: str
+   * required: optional
+   * description: The port in which http server is hosting the redhat repository like "81" and is used in roles as http://abc.com:81/
+
+3. repo_dir:
+   * type: str
+   * required: optional
+   * description: The path in which http server is hosting the redhat repository, can be in default path /var/www/html/ a directory "crtl". Specify in        format "crtl", this is used in roles as http://abc.com:81/crtl/
+
+4. curr_hmc_auth:
+   * type: str
+   * required: true
+   * description: Username and Password to login to HMC system, For security purposes, it is highly recommended to store this sensitive information in        an encrypted secret vault file.
+
+5. host_ip/host_gw/host_subnet/host_netmask: 
+   * type: str
+   * required: true
+   * description: lpar Network details in format 9.9.9.9
+
+6. dns_ip: 
+   * type: str
+   * required: true
+   * description: Nameserver IP details in format 9.1.1.1
+
+7. hostname: 
+   * type: str
+   * required: true
+   * description: hostname of the lpar in format aaa.abc.com
+
+8. lpar_name: 
+   * type: str
+   * required: true
+   * desription: name of lpar as in the HMC 
+
+9. hardware_ethernet: 
+   * type: str
+   * required: true
+   * description: MAC address of the lpar in format ff:ff:ff:ff
+
+10. managed_system: 
+    * type: str
+    * required: true
+    * description: system name in HMC in which lpar is available 
+
+Example Playbook
+----------------
+        ---
+        - name: Redhat Install linux
+          hosts: localhost
+          collections:
+            - ibm.power_hmc
+          gather_facts: false
+          roles:
+            - role: redhat_linux_install
+              vars:
+                host_ip: 9.9.9.9
+                host_gw: 9.9.9.1
+                host_subnet: 9.9.9.0
+                host_netmask: 255.255.255.0
+                dns_ip: 9.1.1.1
+                hostname: aaa.abc.com
+                lpar_name: name_in_hmc
+                hardware_ethernet: ff:ff:ff:ff
+                managed_system: system_name_in_HMC
+
+Inventory file with detials of pxe server, repository server and HMC server is required while running the playbook
+---------
+For security purposes, it is highly recommended to store this sensitive information in an encrypted secret vault file.
+        
+	[repo]
+        repo_server  ansible_host=9.4.4.4 ansible_user=abc ansible_password=1234
+        [pxe]
+        pxe_server   ansible_host=9.3.3.3 ansible_user=abc ansible_password=1234
+        [hmcs]
+        hmc_server   ansible_host=hmc.com
+
+-----------
+License
+-------
+
+GPL-3.0-only
+
+Author Information
+------------------
+
+Spoorthy S
+

--- a/roles/redhat_linux_install/README.rst
+++ b/roles/redhat_linux_install/README.rst
@@ -1,0 +1,141 @@
+Role Name
+=========
+
+This Ansible role "Red Hat Linux Installation for IBM PowerVM" automates the process of installing Red Hat Enterprise Linux (RHEL) on IBM PowerVM logical partitions (LPARs) using a **network-based installation via TFTP boot**.
+
+## Overview
+
+There are multiple ways to install RHEL on IBM Power servers. This role focuses on automating the **TFTP-based network installation** method using Ansible. It sets up the necessary infrastructure and orchestrates the installation process end-to-end.
+
+## Required Infrastructure
+
+To perform the installation, the following components must be configured:
+
+1. **HTTP (Repo) Server**  
+   Hosts the RHEL distribution files and serves them via HTTP. This can be a dedicated server with multiple distro builds or a simple HTTP server with the required build.
+
+2. **PXE Server**  
+   Runs both `tftpd` and `dhcpd` services. This role will configure these services if they are not already running.
+
+3. **LPAR (Logical Partition)**  
+   The target system where RHEL will be installed.
+
+## Role Workflow
+
+1. **PXE Server Setup**  
+   - Checks for running DHCP and TFTP services.
+   - If not found, configures and enables them.
+   - DHCP configuration is dynamically generated based on the subnet of the target LPAR using the `dhcp_server_conf.j2` template.
+   - TFTP is configured to serve files from `/var/lib/tftpboot`.
+
+2. **Kickstart File Generation**  
+   - A kickstart file is created on the HTTP server containing the installation configuration.
+
+3. **Boot File Preparation**  
+   - Required boot files are downloaded to the PXE server.
+   - A GRUB configuration file is generated using the kickstart file.
+
+4. **Network Boot Trigger**  
+   - The `lpar_netboot` command is executed from the HMC to initiate a network boot on the LPAR.
+   - The LPAR sends a BOOTP request to the PXE server and begins the OS installation.
+
+5. **Post-Installation Validation**
+   - After installation, the role prints the OS distribution name and version installed on the LPAR to verify success.
+
+
+Role Variables
+--------------
+
+1. distro:  
+   * type: str
+   * required: true
+   * description: Redhat distribution version in format Redhat9.3
+
+2. repo_port:
+   * type: str
+   * required: optional
+   * description: The port in which http server is hosting the redhat repository like "81" and is used in roles as http://abc.com:81/
+
+3. repo_dir:
+   * type: str
+   * required: optional
+   * description: The path in which http server is hosting the redhat repository, can be in default path /var/www/html/ a directory "crtl". Specify in        format "crtl", this is used in roles as http://abc.com:81/crtl/
+
+4. curr_hmc_auth:
+   * type: str
+   * required: true
+   * description: Username and Password to login to HMC system, For security purposes, it is highly recommended to store this sensitive information in        an encrypted secret vault file.
+
+5. host_ip/host_gw/host_subnet/host_netmask: 
+   * type: str
+   * required: true
+   * description: lpar Network details in format 9.9.9.9
+
+6. dns_ip: 
+   * type: str
+   * required: true
+   * description: Nameserver IP details in format 9.1.1.1
+
+7. hostname: 
+   * type: str
+   * required: true
+   * description: hostname of the lpar in format aaa.abc.com
+
+8. lpar_name: 
+   * type: str
+   * required: true
+   * desription: name of lpar as in the HMC 
+
+9. hardware_ethernet: 
+   * type: str
+   * required: true
+   * description: MAC address of the lpar in format ff:ff:ff:ff
+
+10. managed_system: 
+    * type: str
+    * required: true
+    * description: system name in HMC in which lpar is available 
+
+Example Playbook
+----------------
+        ---
+        - name: Redhat Install linux
+          hosts: localhost
+          collections:
+            - ibm.power_hmc
+          gather_facts: false
+          roles:
+            - role: redhat_linux_install
+              vars:
+                host_ip: 9.9.9.9
+                host_gw: 9.9.9.1
+                host_subnet: 9.9.9.0
+                host_netmask: 255.255.255.0
+                dns_ip: 9.1.1.1
+                hostname: aaa.abc.com
+                lpar_name: name_in_hmc
+                hardware_ethernet: ff:ff:ff:ff
+                managed_system: system_name_in_HMC
+
+Inventory file with detials of pxe server, repository server and HMC server is required while running the playbook
+---------
+For security purposes, it is highly recommended to store this sensitive information in an encrypted secret vault file.
+        
+	[repo]
+        repo_server  ansible_host=9.4.4.4 ansible_user=abc ansible_password=1234
+        [pxe]
+        pxe_server   ansible_host=9.3.3.3 ansible_user=abc ansible_password=1234
+        [hmcs]
+        hmc_server   ansible_host=hmc.com
+
+-----------
+License
+-------
+
+GPL-3.0-only
+
+Author Information
+------------------
+
+Spoorthy S
+

--- a/roles/redhat_linux_install/meta/main.yml
+++ b/roles/redhat_linux_install/meta/main.yml
@@ -1,0 +1,12 @@
+galaxy_info:
+  author: Spoorthy S
+  description: Redhat Linux installation using pxe server
+  license: GPL-3.0-only
+  min_ansible_version: '>=2.14.0'
+  galaxy_tags:
+    - infrastructure
+    - ibm
+    - power
+    - hmc
+    - linux
+    - pxe

--- a/roles/redhat_linux_install/tasks/main.yml
+++ b/roles/redhat_linux_install/tasks/main.yml
@@ -1,0 +1,277 @@
+---
+- name: Gather service facts
+  run_once: true
+  service_facts:
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Check if the pxe server has dhcp and tftp services running
+  run_once: true
+  set_fact:
+    dhcpd_running: "{{ 'dhcpd.service' in services and services['dhcpd.service'].state == 'running' }}"
+    tftp_running: >-
+      {{ ('tftp.service' in services and services['tftp.service'].state == 'running') or
+         ('xinetd.service' in services and services['xinetd.service'].state == 'running') }}
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Install dhcp in pxe server
+  block:
+    - name: Install dhcp in pxe server
+      dnf:
+        name:
+          - dhcp-server
+        state: present
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+    - name: Calculate DHCP range from IP (assuming /24 subnet) using bash only
+      shell: |
+          ip="{{ host_subnet }}"
+          # Assume /24 subnet
+          cidr=24
+          netmask="255.255.255.0"
+
+          # Extract network base IP
+          IFS=. read -r o1 o2 o3 o4 <<< "$ip"
+          network="${o1}.${o2}.${o3}.0"
+
+          ip_to_dec() {
+          IFS=. read -r a b c d <<< "$1"
+          echo $(( (a << 24) + (b << 16) + (c << 8) + d ))
+          }
+
+          dec_to_ip() {
+          a=$(( ($1 >> 24) & 255 ))
+          b=$(( ($1 >> 16) & 255 ))
+          c=$(( ($1 >> 8) & 255 ))
+          d=$(( $1 & 255 ))
+          echo "$a.$b.$c.$d"
+          }
+
+          net_dec=$(ip_to_dec "$network")
+          mask_dec=$(ip_to_dec "$netmask")
+          broadcast_dec=$(( net_dec | (~mask_dec & 0xFFFFFFFF) ))
+
+          start_dec=$(( net_dec + 10 ))
+          end_dec=$(( broadcast_dec - 1 - 1 ))  # second-to-last usable
+
+          start_ip=$(dec_to_ip "$start_dec")
+          end_ip=$(dec_to_ip "$end_dec")
+
+          echo "dhcp_range_start=$start_ip"
+          echo "dhcp_range_end=$end_ip"
+      register: dhcp_range_output
+
+    - name: Set DHCP range facts
+      set_fact:
+        dhcp_range_start: "{{ dhcp_range_output.stdout_lines | select('search', '^dhcp_range_start=') | first | regex_replace('^dhcp_range_start=', '') }}"
+        dhcp_range_end: "{{ dhcp_range_output.stdout_lines | select('search', '^dhcp_range_end=') | first | regex_replace('^dhcp_range_end=', '') }}"
+
+    - name: Debug
+      debug:
+        msg: "{{ dhcp_range_start }} {{ dhcp_range_end }}"
+
+    - name: Add block for dhcp configuration
+      run_once: true
+      template:
+        src: templates/dhcp_server_conf.j2
+        dest: "/etc/dhcp/dhcpd.conf"
+        owner: root
+        group: root
+        mode: '0644'
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+    - name: Enable and start dhcp-server
+      systemd:
+        name: dhcpd
+        state: started
+        enabled: true
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+    - name: Open DHCP ports in firewall
+      firewalld:
+        service: dhcp
+        permanent: true
+        state: enabled
+        immediate: true
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+  when: not dhcpd_running
+
+- name: Install tftp in pxe server
+  block:
+    - name: Install tftp in pxe server
+      dnf:
+        name: tftp-server
+        state: present
+        use_backend: dnf4
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+    - name: Ensure TFTP root directory exists
+      file:
+        path: /var/lib/tftpboot
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+      delegate_to: "{{ groups['pxe'][0] }}"
+    
+    - name: Enable and start tftp-socket
+      systemd:
+        name: tftp.socket
+        state: started
+        enabled: true
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+    - name: Enable and start tftp-server
+      systemd:
+        name: tftp.service
+        state: started
+        enabled: true
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+    - name: Install grub2-tools-extra and wget package in pxe server
+      dnf:
+        name: grub2-tools-extra
+        state: present
+        use_backend: dnf4
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+    - name: Install wget package in pxe server
+      dnf:
+        name: wget
+        state: present
+        use_backend: dnf4
+      delegate_to: "{{ groups['pxe'][0] }}"
+
+    - name: Open TFTP ports in firewall
+      firewalld:
+        service: tftp
+        permanent: true
+        state: enabled
+        immediate: true
+      delegate_to: "{{ groups['pxe'][0] }}"
+  when: not tftp_running
+
+- name: Create Kickstart file name
+  set_fact:
+    ks_file: "{{ distro | regex_replace('\\.', '') }}_{{ hardware_ethernet }}.ks"
+
+- name: Create a kickstart file in Repository server
+  run_once: true
+  template:
+    src: templates/ks.j2
+    dest: "/var/www/html/{{ ks_file }}"
+  delegate_to: "{{ groups['repo'][0] }}"
+
+- name: Remove any existing tftp boot folder in PXE server for this VM
+  run_once: true
+  shell: rm -rf "{{ dest_dir }}"
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Calculate cutdir value
+  shell: echo "{{ repo_dir }}" | tr '/' '\n' | grep -v "^$" | wc -l
+  register: cut_dir
+
+- name: Download files from /boot and /ppc directory in Repository Server to the PXE server tftp path(hardware address)
+  run_once: true
+  shell: wget -r --reject="index.html*" --no-parent -nH --cut-dir={{ cut_dir.stdout | int + 1 }}   http://{{ hostvars[groups['repo'][0]].ansible_host }}:{{ repo_port }}/{{ repo_dir }}/boot/ -P {{ dest_dir }}  
+  delegate_to: "{{ groups['pxe'][0] }}" 
+
+- name: Download files from /boot and /ppc directory in Repository Server to the PXE server tftp path(hardware address)
+  run_once: true
+  shell: wget -r --reject="index.html*" --no-parent -nH --cut-dir={{ cut_dir.stdout | int + 1 }}   http://{{ hostvars[groups['repo'][0]].ansible_host }}:{{ repo_port }}/{{ repo_dir }}/ppc/ -P {{ dest_dir }}
+  delegate_to: "{{ groups['pxe'][0] }}"
+  
+- name: Create netboot directory in PXE server under tftp path
+  run_once: true
+  shell: grub2-mknetdir --net-directory={{ base_dir }} --subdir={{ mac_address }}/boot/grub/
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Create grub.cfg and copy to boot directory in PXE server
+  run_once: true 
+  template:
+    src: templates/grub_conf.j2
+    dest: "{{ dest_dir }}/boot/grub/grub.cfg"
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: copy to grub.cfg to boot directory in PXE server
+  run_once: true
+  shell: cp "{{ dest_dir }}/boot/grub/grub.cfg" "{{ dest_dir }}/boot/grub/powerpc-ieee1275/grub.cfg-01-{{ address }}"
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Backup the dhcp file , if in case this blocks add any errors
+  run_once: true
+  shell: cp /etc/dhcp/dhcpd.conf /tmp/dhcpd.conf
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: DHCP block file to add lpar entry into dhcpd.conf
+  run_once: true
+  blockinfile:
+    dest: /etc/dhcp/dhcpd.conf
+    marker: "#{mark} Ansible module dhcp entry"
+    block: "{{ lookup('template', 'dhcpd_conf.j2') }}"
+    state: present
+  delegate_to: "{{ groups['pxe'][0] }}"
+   
+- name: restart dhcp service
+  run_once: true
+  shell: systemctl restart  dhcpd.service
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Lparnetboot operation on target lpar
+  run_once: true
+  connection: local
+  collections:
+      - ibm.power_hmc
+  powervm_lpar_instance:
+        hmc_host: "{{ hostvars[groups['hmcs'][0]].ansible_host }}"
+        hmc_auth: "{{ curr_hmc_auth }}"
+        system_name: "{{ managed_system }}"
+        vm_name: "{{ lpar_name }}"
+        install_settings:
+          vm_ip: "{{ host_ip }}"
+          nim_ip: "{{ hostvars[groups['pxe'][0]].ansible_host }}"
+          nim_gateway: "{{ host_gw }}"
+          nim_subnetmask: "{{ host_netmask }}"
+          vm_mac: "{{ mac_address }}"
+          timeout: 11
+        action: install_os
+  ignore_errors: yes
+  delegate_to: "{{ groups['hmcs'][0] }}"
+
+- name: Revert the DHCP configuration changes in PXE server, take a backup of configuration file
+  run_once: true
+  shell: cp /etc/dhcp/dhcpd.conf /tmp/dhcpd.conf
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: block file
+  run_once: true
+  blockinfile:
+    dest: /etc/dhcp/dhcpd.conf
+    marker: "#{mark} Ansible module dhcp entry"
+    block: "{{ lookup('template', 'dhcpd_conf.j2') }}"
+    state: absent
+  delegate_to: "{{ groups['pxe'][0] }}"
+  
+- name: resatart dhcp
+  run_once: true
+  shell: systemctl restart  dhcpd.service
+  delegate_to: "{{ groups['pxe'][0] }}"
+
+- name: Wait for host SSH to become available after install
+  run_once: true
+  wait_for_connection:
+    timeout: 10
+    sleep: 5
+  vars:
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+  delegate_to: "{{ groups['vm'][0] }}"
+
+- name: Ensure system facts are gathered from the VM
+  run_once: true
+  setup:
+  delegate_to: "{{ groups['vm'][0] }}"
+
+- name: Print OS info from the VM
+  run_once: true
+  debug:
+    msg: "Distribution: {{ ansible_facts['distribution'] }}, Version: {{ ansible_facts['distribution_version'] }}"

--- a/roles/redhat_linux_install/templates/dhcp_server_conf.j2
+++ b/roles/redhat_linux_install/templates/dhcp_server_conf.j2
@@ -1,0 +1,8 @@
+default-lease-time 600;
+max-lease-time 7200;
+authoritative;
+subnet {{ host_subnet }} netmask {{ host_netmask }} {
+  range {{dhcp_range_start}} {{ dhcp_range_end }};
+  option routers {{ host_gw }};
+  option domain-name-servers {{ dns_ip }};
+}

--- a/roles/redhat_linux_install/templates/dhcpd_conf.j2
+++ b/roles/redhat_linux_install/templates/dhcpd_conf.j2
@@ -1,0 +1,15 @@
+subnet {{ host_subnet }} netmask {{ host_netmask }} {
+    allow bootp;
+    option routers {{ host_gw }};
+    option domain-name-servers {{ dns_ip }};
+    group {
+        next-server {{ hostvars[groups['pxe'][0]].ansible_host }};
+        filename "{{ core_file_path }}";
+        host {{ hostname }} {
+            hardware ethernet {{ hardware_ethernet }};
+            fixed-address {{ host_ip }};
+            option host-name {{ lpar_name }};
+            option tftp-server-name "{{ hostvars[groups['pxe'][0]].ansible_host }}";
+        }
+    }
+}

--- a/roles/redhat_linux_install/templates/grub_conf.j2
+++ b/roles/redhat_linux_install/templates/grub_conf.j2
@@ -1,0 +1,9 @@
+set timeout=1
+menuentry 'Install OS' {
+    insmod http
+    insmod tftp
+    set root=tftp,{{ hostvars[groups['pxe'][0]].ansible_host }}
+    echo 'Loading OS Install kernel ...'
+    linux {{ mac_address }}/ppc/ppc64/vmlinuz ifname=net0:{{ hardware_ethernet }} ip={{ host_ip }}::{{ host_gw }}:{{ host_netmask }}:{{ hostname }}:net0:none nameserver={{ dns_ip }} inst.repo=http://{{ hostvars[groups['repo'][0]].ansible_host }}:{{ repo_port }}/{{ repo_dir }}/ inst.ks=http://{{ hostvars[groups['repo'][0]].ansible_host }}:{{ repo_port }}/{{ ks_file }}
+    initrd {{ mac_address }}/ppc/ppc64/initrd.img
+}

--- a/roles/redhat_linux_install/templates/ks.j2
+++ b/roles/redhat_linux_install/templates/ks.j2
@@ -1,0 +1,56 @@
+%pre
+%end
+# Use network installation
+url --url="http://{{ hostvars[groups['repo'][0]].ansible_host }}:{{ repo_port }}/{{ repo_dir }}/BaseOS"
+
+# Use text mode install
+text
+
+# Keyboard layouts
+keyboard --vckeymap=us --xlayouts='us'
+
+# System language
+lang en_US.UTF-8
+
+# Root password
+rootpw --plaintext {{ host_password }}
+
+# Do not configure the X Window System
+skipx
+
+# System timezone
+timezone Asia/Kolkata --utc
+
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
+clearpart --all --initlabel --drives=sda
+
+# System bootloader configuration
+bootloader --append="crashkernel=2G-4G:384M,4G-16G:512M,16G-64G:1G,64G-128G:2G,128G-:4G" --location=mbr --boot-drive=sda
+
+
+# Generated using Blivet version 3.6.0
+ignoredisk --only-use=sda
+
+autopart --fstype=ext4
+
+# System services
+services --enabled="NetworkManager,sshd"
+
+# Reboot after installation
+reboot
+
+%packages
+@core
+device-mapper-multipath
+kexec-tools
+%end
+
+%post
+sed -i 's/#\?PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config;service sshd restart;multipath -t >/etc/multipath.conf;service multipathd start
+%end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+
+%end

--- a/roles/redhat_linux_install/vars/main.yml
+++ b/roles/redhat_linux_install/vars/main.yml
@@ -1,0 +1,46 @@
+---
+
+# Redhat Release Name
+distro: 
+
+# Repository Port Number 
+repo_port: 
+
+# Path to the build files in Repository server
+repo_dir: 
+
+# Tftp boot directory path in PXE server
+base_dir: /var/lib/tftpboot/
+
+# Remove ':' in hardware ethernet address
+mac_address: "{{ hardware_ethernet | regex_replace(':', '') }}"
+
+# Append base directory path with a new directory named by mac address
+dest_dir: "{{ base_dir }}{{ mac_address }}"
+
+# Set core elf file path in PXE server
+core_file_path: "{{ mac_address }}/boot/grub/powerpc-ieee1275/core.elf"
+
+# Replace ':' in hardware ethernet address wit '-'
+address: "{{ hardware_ethernet | regex_replace(':', '-') }}"
+
+# HMC credentials
+curr_hmc_auth:
+        username: "{{ hostvars[groups['hmcs'][0]].ansible_user }}"
+        password: "{{ hostvars[groups['hmcs'][0]].ansible_password }}"
+
+# Host Details
+host_ip: 9.1.1.10
+host_gw: 9.1.1.1
+host_subnet: 9.1.1.0
+host_netmask: 255.255.255.0
+dns_ip: 9.0.0.0
+hostname: vm.abc.com
+lpar_name: vm-hmc
+hardware_ethernet: aa:aa:aa:aa:aa:aa 
+managed_system: vm-abc
+host_password: password
+
+
+
+


### PR DESCRIPTION
Role have been added to automate linux installation and roles has below steps to achieve it ,
1. Kickstart file creation - Drive the automated OS installation
2. DHCP  in pxe server- Add the lpar entry in DHCP config file inside DHCP server
3. TFTP in pxe server - Add the tftp/grub related files for OS to be installed in accordance with lpar mac address
4. DHCP cleanup in pxe server - cleanup the DHCP config for the lpar created

This role will take care to start and enable the dhcp and tftp server on PXE server, if its unavailable 